### PR TITLE
fix(trailing-whitespace): allow Markdown hard linebreaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   rev: v3.4.0
   hooks:
   - id: trailing-whitespace
+    args: [--markdown-linebreak-ext=md]
   - id: end-of-file-fixer
   - id: mixed-line-ending
 - repo: https://github.com/Lucas-C/pre-commit-hooks


### PR DESCRIPTION
Hello @Sh4d1 !

A good parameter for your Markdown files :P

cf: https://github.com/pre-commit/pre-commit-hooks#trailing-whitespace